### PR TITLE
add PR template validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- -----------^ Click "Preview" for a functional view! -->
 
 ## Why are you creating this Pull Request?
+### Please select one of the following links and follow the provided template
 
 - [Adding Datasets or Stories](?title=Content%3A%20%3Cname%3E&expand=1&template=content.md)
 - [Version Release](?title=Deploy%20vX.X.X&expand=1&template=version_release.md)

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,19 @@
+name: 'PR description checker'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jadrol/pr-description-checker-action@v1.0.0
+        id: description-checker
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What am I changing and why

I've added a bit of clarification on the PR template and then added a github action to validate that a description other than the text in the `PULL_REQUEST_TEMPLATE.md` is used.

## How to test
This can be seen by creating a PR and not editing the template.  Screenshot of that case:

<img width="1169" alt="Screenshot 2023-11-28 at 10 50 33 AM" src="https://github.com/NASA-IMPACT/veda-config-ghg/assets/7388976/277bbc67-5f41-424a-b613-065a39b3fb77">


Now that the template is edited, look to see that the test step has passed.

## ⚠️ Checks

- [x ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.