### PR TITLE
Pass maxzoom as sourceparam for methane gridded dataset

### DIFF
--- a/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
+++ b/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
@@ -52,6 +52,8 @@ layers:
       rescale:
         - 0
         - 20
+      minzoom: 0
+      maxzoom: 7
       # nodata: -9999
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express

--- a/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
+++ b/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
@@ -53,7 +53,7 @@ layers:
         - 0
         - 20
       minzoom: 0
-      maxzoom: 7
+      maxzoom: 5
       # nodata: -9999
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express


### PR DESCRIPTION
<!-- -----------^ Click "Preview" for a functional view! -->

## Why are you creating this Pull Request?

- Opening this to see if setting up maxzoom resolves https://github.com/NASA-IMPACT/veda-ui/issues/754

@slesaad I remember we discussed this issue a while ago. I don't know the dataset very well (like what the actual maxzoom is?) but setting the maxzoom on `sourceParams` level seems to solve the issues for me. Can you confirm? 

The overzoomed data looks blurry. We can work around this by setting up `raster-resampling` to `nearest` (currently, it is default which is `linear`. but I want to confirm if setting maxzoom for sourceParams resolve the issue,)


Preview: https://deploy-preview-260--ghg-demo.netlify.app/data-catalog/epa-ch4emission-yeargrid-v2express/explore?projection=equirectangular%7C%7C&basemapid=light&datetime=2020-01-01T00%3A00%3A00.000Z&position=-95.4236%7C40.4484%7C8.39