### PR TITLE
Update veda-ui submodules ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".veda/ui"]
   path = .veda/ui
-  url = ../veda-ui.git
+  url = https://github.com/NASA-IMPACT/veda-ui.git


### PR DESCRIPTION
## What am I changing and why

When the repository was transferred from NASA-IMPACT org to US-GHG-Center, the submodule ref which was `../veda-ui.git` was no longer valid. 

Replacing with the full repository URL to fix that.

## How to test
Clone new `veda-config-ghg` and run through the setup process. It won't throw the following error anymore:
```bash
fatal: clone of ‘git@github.com:US-GHG-Center/veda-ui.git’ into submodule path ‘/<path>/veda-config-ghg/.veda/ui’ failed
```