### PR TITLE
Add DAP tracking code

### DIFF
--- a/.env
+++ b/.env
@@ -20,10 +20,17 @@ MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 # PUBLIC_URL=http://example.com/mysite
 
 # Google form for feedback
-GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSeVWCrnca08Gt_qoWYjTo6gnj1BEGL4NCUC9VEiQnXA02gzVQ/viewform'
+GOOGLE_FORM='https://docs.google.com/forms/d/e/1FAIpQLSeVWCrnca08Gt_qoWYjTo6gnj1BEGL4NCUC9VEiQnXA02gzVQ/viewform'
 
 # Temporarily add hub link through env variables.
 # This does not scale for the different instances, but it's a quick fix for the
 # GHG app.
-HUB_URL = 'https://hub.ghg.center/'
-HUB_NAME = 'Hub'
+HUB_URL='https://hub.ghg.center/'
+HUB_NAME='Hub'
+
+# Ass DAP script block with tracking code for the DAP compliance. 
+# Every public-facing NASA website must install the DAP tracking code on all public-facing pages.
+# This federal requirement was first published in OMB M-17-06 (issued in 2016) and was re-issued in OMB M-23-22 in September 2023. 
+
+CUSTOM_SCRIPT_SRC=https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=HQ
+CUSTOM_SCRIPT_ID=_fed_an_ua_tag

--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ GOOGLE_FORM='https://docs.google.com/forms/d/e/1FAIpQLSeVWCrnca08Gt_qoWYjTo6gnj1
 HUB_URL='https://hub.ghg.center/'
 HUB_NAME='Hub'
 
-# Ass DAP script block with tracking code for the DAP compliance. 
+# Add DAP script block with tracking code for the DAP compliance. 
 # Every public-facing NASA website must install the DAP tracking code on all public-facing pages.
 # This federal requirement was first published in OMB M-17-06 (issued in 2016) and was re-issued in OMB M-23-22 in September 2023. 
 


### PR DESCRIPTION
# Description
> Every public-facing NASA website must install the DAP tracking code on all public-facing pages. This federal requirement was first published in OMB M-17-06 (issued in 2016) and was re-issued in OMB M-23-22 in September 2023. 

This PR adds the tracking code via env vars. [The corresponding PR](https://github.com/NASA-IMPACT/veda-ui/pull/846) in veda-ui was merged.
