### PR TITLE
Change GOSAT colormap to spectral_r

### DIFF
--- a/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
+++ b/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
@@ -68,16 +68,16 @@ layers:
       min: 0
       max: 0.3
       stops:
-        - '#000080'
-        - '#0000FF'
-        - '#0080FF'
-        - '#00FFFF'
-        - '#00FF80'
-        - '#FFFF00'
-        - '#FF8000'
-        - '#FF0000' 
-        - '#800000' 
-        - '#4C0000'
+        - '#5e4fa2'
+        - '#388eba'
+        - '#75c8a5'
+        - '#bfe5a0'
+        - '#f1f9a9'
+        - '#feeea2'
+        - '#fdbf6f'
+        - '#f67b4a' 
+        - '#d8434e' 
+        - '#9e0142'
     analysis:
       metrics:
         - mean
@@ -114,14 +114,16 @@ layers:
       min: 0
       max: 0.3
       stops:
-        - '#000080'
-        - '#0010FF'
-        - '#00A4FF'
-        - '#40FFB7'
-        - '#B7FF40'
-        - '#FFB900'
-        - '#FF3000'
-        - '#800000' 
+        - '#5e4fa2'
+        - '#388eba'
+        - '#75c8a5'
+        - '#bfe5a0'
+        - '#f1f9a9'
+        - '#feeea2'
+        - '#fdbf6f'
+        - '#f67b4a' 
+        - '#d8434e' 
+        - '#9e0142'
     analysis:
       metrics:
         - mean
@@ -158,16 +160,16 @@ layers:
       min: 0
       max: 0.10
       stops:
-        - '#000080'
-        - '#0000FF'
-        - '#0080FF'
-        - '#00FFFF'
-        - '#00FF80'
-        - '#FFFF00'
-        - '#FF8000'
-        - '#FF0000' 
-        - '#800000' 
-        - '#4C0000'   
+        - '#5e4fa2'
+        - '#388eba'
+        - '#75c8a5'
+        - '#bfe5a0'
+        - '#f1f9a9'
+        - '#feeea2'
+        - '#fdbf6f'
+        - '#f67b4a' 
+        - '#d8434e' 
+        - '#9e0142'
     analysis:
       metrics:
         - mean        
@@ -204,16 +206,16 @@ layers:
       min: 0
       max: 0.10
       stops:
-        - '#000080'
-        - '#0000FF'
-        - '#0080FF'
-        - '#00FFFF'
-        - '#00FF80'
-        - '#FFFF00'
-        - '#FF8000'
-        - '#FF0000' 
-        - '#800000' 
-        - '#4C0000' 
+        - '#5e4fa2'
+        - '#388eba'
+        - '#75c8a5'
+        - '#bfe5a0'
+        - '#f1f9a9'
+        - '#feeea2'
+        - '#fdbf6f'
+        - '#f67b4a' 
+        - '#d8434e' 
+        - '#9e0142'
     analysis:
       metrics:
         - mean

--- a/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
+++ b/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
@@ -49,7 +49,7 @@ layers:
       - 20
     sourceParams:
       assets: prior-total
-      colormap_name: jet
+      colormap_name: spectral_r
       rescale:
         - 0
         - 0.3
@@ -95,7 +95,7 @@ layers:
       - 20
     sourceParams:
       assets: post-total
-      colormap_name: jet
+      colormap_name: spectral_r
       rescale:
         - 0
         - 0.3
@@ -139,7 +139,7 @@ layers:
       - 20
     sourceParams:
       assets: prior-wetland
-      colormap_name: jet
+      colormap_name: spectral_r
       rescale:
         - 0
         - 0.10
@@ -185,7 +185,7 @@ layers:
       - 20
     sourceParams:
       assets: post-wetland
-      colormap_name: jet
+      colormap_name: spectral_r
       rescale:
         - 0
         - 0.10


### PR DESCRIPTION
- [x] Changed colormap for GOSAT layers to `spectral_r` based on advice from Emily and confirmation from John
- [x] Changed in both dynamic rendering parameters (TiTiler) and legend stops

New looks:

![image](https://github.com/US-GHG-Center/veda-config-ghg/assets/3404817/fdc352d2-f400-4f8c-9463-fe1c4a64a1c8)