### PR TITLE
Update custom interfaces links to new in-domain links

### DIFF
--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -106,7 +106,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://staging.earth.gov/ghgcenter/custom-interfaces/emit-ch4plume-v1"
+      src="https://earth.gov/ghgcenter/custom-interfaces/emit-ch4plume-v1"
     />
   </Figure>
 </Block>

--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -106,7 +106,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://nasa-impact.github.io/interactive-emission-plumes"
+      src="https://staging.earth.gov/ghgcenter/custom-interfaces/emit-ch4plume-v1"
     />
   </Figure>
 </Block>

--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -94,7 +94,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://nasa-impact.github.io/noaa-viz?ghg=ch4&type=flask"
+      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=ch4&type=flask"
     />
   </Figure>
 </Block>

--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -94,7 +94,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=ch4&type=flask"
+      src="https://earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=ch4&type=flask"
     />
   </Figure>
 </Block>

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -93,7 +93,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://nasa-impact.github.io/noaa-viz?ghg=co2&type=flask"
+      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=co2&type=flask"
     />
   </Figure>
 </Block>

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -93,7 +93,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=co2&type=flask"
+      src="https://earth.gov/ghgcenter/custom-interfaces/noaa-cpfp-point?ghg=co2&type=flask"
     />
   </Figure>
 </Block>


### PR DESCRIPTION
# Changes
Updates the custom interfaces links from GitHub pages links to earth.gov/* links.
