### PR TITLE
Add min/max zoom params to avoid getting garbage data on zoom

### DIFF
--- a/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
+++ b/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
@@ -53,6 +53,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-methane
@@ -117,6 +119,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-agriculture
@@ -181,6 +185,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: enteric-fermentation
@@ -245,6 +251,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: manure-management
@@ -309,6 +317,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: rice-cultivation-l
@@ -373,6 +383,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: field-burning-l
@@ -437,6 +449,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-natural-gas
@@ -501,6 +515,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: exploration-ngs-l
@@ -565,6 +581,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: production-ngs-l
@@ -629,6 +647,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2b-transmission-storage-ngs
@@ -693,6 +713,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2b-processing-ngs
@@ -757,6 +779,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2b-distribution-ngs
@@ -821,6 +845,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: post-meter-ng
@@ -885,6 +911,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-petroleum
@@ -949,6 +977,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2a-exploration-ps
@@ -1013,6 +1043,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2a-production-ps
@@ -1077,6 +1109,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2a-transport-ps
@@ -1141,6 +1175,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B2a-refining-ps
@@ -1205,6 +1241,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-waste
@@ -1269,6 +1307,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 5A1-msw-landfill-waste
@@ -1333,6 +1373,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 5A1-industrial-landfill-waste
@@ -1397,6 +1439,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 5A1-dwtd-waste
@@ -1461,6 +1505,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 5A1-iwtd-waste
@@ -1525,6 +1571,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 5A1-composting-waste
@@ -1589,6 +1637,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-coal-mines
@@ -1653,6 +1703,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B1a-underground-coal
@@ -1717,6 +1769,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B1a-abn-underground-coal
@@ -1781,6 +1835,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1B1a-surface-coal
@@ -1845,6 +1901,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: total-other
@@ -1909,6 +1967,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1A-stationary-combustion-other
@@ -1973,6 +2033,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1A-mobile-combustion-othe
@@ -2037,6 +2099,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1A-abn-ong-other
@@ -2101,6 +2165,8 @@ layers:
         - 0
         - 20
       # nodata: -9999
+      minzoom: 0
+      maxzoom: 6
     compare:
       datasetId: epa-ch4emission-yeargrid-v2express
       layerId: 1A-petro-production-other


### PR DESCRIPTION
## What am I changing and why

Related issues:
https://github.com/NASA-IMPACT/veda-ui/issues/754
https://github.com/US-GHG-Center/veda-config-ghg/pull/260

- Adding min/max zoom to EPA methane layers to avoid garbage data on zoom (see video in the first link ☝️ )

After a long back and forth about this issue, we've landed on this solution.

## How to test
zoom in to colorado springs and verify this issue no longer exists
