### PR TITLE
Fix dataset id

### DIFF
--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -112,7 +112,7 @@ taxonomy:
     <Chapter
         center={[-26.262383, -1.342390]}
         zoom={3}
-        datasetId='lpjwsl-wetlandch4-grid-v1'
+        datasetId='lpjeosim-wetlandch4-grid-v2'
         layerId='ch4-wetlands-emissions'
         datetime='2021-08-01'
     >
@@ -121,7 +121,7 @@ taxonomy:
     <Chapter
         center={[-99.513843, 55.655443]}
         zoom={3}
-        datasetId='lpjwsl-wetlandch4-grid-v1'
+        datasetId='lpjeosim-wetlandch4-grid-v2'
         layerId='ch4-wetlands-emissions'
         datetime='2021-08-01'
     >


### PR DESCRIPTION
## What am I changing and why

It looks like the dataset id used for the "tracking-greenhouse-gas-cycles" story doesn't exist anymore. I guessed the new dataset should be `lpjeosim-wetlandch4-grid-v2` since it has the layer, but please check before merge.