### PR TITLE
Make EPA dataset source-exclusive in E&A

### DIFF
--- a/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
+++ b/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
@@ -33,6 +33,7 @@ taxonomy:
   - name: Product Type
     values:
       - Gridded Inventory
+sourceExclusive: EPA
 infoDescription: |
   ::markdown
     - Temporal Extent: 2012 - 2020    


### PR DESCRIPTION
We were somehow missing this important configuration for the EPA dataset.

- [x] Add `sourceExclusive` to the EPA gridded methane inventory dataset