### PR TITLE
Add video modal override component for GHGC Demo Video

### DIFF
--- a/overrides/components/video-modal/index.tsx
+++ b/overrides/components/video-modal/index.tsx
@@ -1,0 +1,65 @@
+import React from "$veda-ui/react";
+import styled, { useTheme } from "$veda-ui/styled-components";
+import { Modal, ModalBody, ModalHeader } from '$veda-ui/@devseed-ui/modal';
+import { Button } from '$veda-ui/@devseed-ui/button';
+import { CollecticonXmarkSmall } from '$veda-ui/@devseed-ui/collecticons';
+
+const ModalContainer = styled(Modal)<{ width?: string; height?: string }>`
+  div {
+    background: none;
+  }
+
+  ${ModalHeader} {
+    display: flex;
+    justify-content: flex-end;
+    width: ${props => props.width ?? '100%'};
+    background: none;
+    padding: 0.5rem 0;
+  }
+
+  ${ModalBody} {
+    padding: 0;
+    margin: 0;
+    width: ${props => props.width ?? '100%'};
+    height: ${props => props.height ?? '100%'};
+    iframe {
+      position: absolute;
+      width: ${props => props.width ?? '100%'};
+      height: ${props => props.height ?? '100%'};
+    }
+  }
+`;
+
+interface VideoModalProps {
+  iframe: JSX.Element;
+  display: boolean;
+  onClose: () => void;
+  width?: string;
+  height?: string;
+}
+
+export default function VideoModal(props: VideoModalProps) {
+  const {iframe, display, onClose, height, width} = props;
+  const theme = useTheme();
+
+  return (
+    <ModalContainer
+      width={width}
+      height={height}
+      id='modal'
+      revealed={display}
+      closeButton={false}
+      renderHeadline={() => (
+        <Button variation='base-text' onClick={onClose}>
+          <CollecticonXmarkSmall size='large' color={theme.color!['surface']}/>
+        </Button>
+      )}
+      content={
+        <>
+          {iframe}
+        </>
+      }
+    />
+
+  );
+}

--- a/overrides/components/video-modal/index.tsx
+++ b/overrides/components/video-modal/index.tsx
@@ -54,11 +54,7 @@ export default function VideoModal(props: VideoModalProps) {
           <CollecticonXmarkSmall size='large' color={theme.color!['surface']}/>
         </Button>
       )}
-      content={
-        <>
-          {iframe}
-        </>
-      }
+      content={iframe}
     />
 
   );

--- a/overrides/home/component.tsx
+++ b/overrides/home/component.tsx
@@ -10,8 +10,8 @@ import { variableGlsp } from "$veda-ui-scripts/styles/variable-utils";
 
 import Partners from "./partners";
 import Keypoints from "./keypoints";
-import { ArrowLink } from "./arrow-link";
 import Banner from './banner';
+import VideoModal from "../components/video-modal";
 
 const HomeContent = styled(Hug)`
   padding: ${variableGlsp(2.5, 0)};
@@ -86,7 +86,16 @@ const InfoCalloutHeadline = styled.div`
   }
 `;
 
+const Buttons = styled.div`
+  display: flex;
+  gap: ${glsp()};
+  justify-content: center;
+`;
+
 export default function HomeComponent() {
+  const [showModal, setShowModal] = React.useState<boolean>(false);
+  const handleOpenModal = () => setShowModal(true);
+  
   return (
     <>
     <Banner />
@@ -106,9 +115,23 @@ export default function HomeComponent() {
           greenhouse gas areas of study, as shown below. The US GHG Center 
           also encourages stakeholder feedback and ideas for future expansion.
           </p>
-          <ArrowLink to="/stories/intro-us-ghg-center">
-            Introduction to the US GHG Center
-          </ArrowLink>
+          <Buttons>
+            <Button
+              onClick={handleOpenModal}
+              size="xlarge"
+              variation="primary-fill"
+            >
+              Tour the US GHG Center
+            </Button>
+            <Button
+              forwardedAs={NavLink}
+              to="/stories/intro-us-ghg-center"
+              size="xlarge"
+              variation="primary-fill"
+            >
+              Learn More
+            </Button>
+          </Buttons>
         </IntroHeadline>
         <Keypoints />
         <ActionsBlock>
@@ -144,6 +167,17 @@ export default function HomeComponent() {
           </Button>
         </InfoCalloutInner>
       </InfoCallout>
+      {
+        showModal && (
+          <VideoModal 
+            iframe={<iframe width="560" height="315" src="https://www.youtube.com/embed/4JVd7pYel0w?si=2at04mgt69Wzt5Mm" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>}
+            display={showModal}
+            onClose={() => setShowModal(false)}
+            width={`${560*1.5}px`} // Iframe's original embed width value 1.5x bigger
+            height={`${315*1.5}px`} // Iframe's original embed height value 1.5x bigger
+          />
+        )
+      }
     </>
   );
 }

--- a/overrides/home/component.tsx
+++ b/overrides/home/component.tsx
@@ -3,7 +3,7 @@ import { NavLink } from "$veda-ui/react-router-dom";
 import styled from "$veda-ui/styled-components";
 import { glsp, themeVal, media } from "$veda-ui/@devseed-ui/theme-provider";
 import { Button } from "$veda-ui/@devseed-ui/button";
-import { CollecticonArrowRight } from "$veda-ui/@devseed-ui/collecticons";
+import { CollecticonArrowRight, CollecticonCirclePlay } from "$veda-ui/@devseed-ui/collecticons";
 import Hug from "$veda-ui-scripts/styles/hug";
 import { VarHeading } from "$veda-ui-scripts/styles/variable-components";
 import { variableGlsp } from "$veda-ui-scripts/styles/variable-utils";
@@ -121,6 +121,7 @@ export default function HomeComponent() {
               size="xlarge"
               variation="primary-fill"
             >
+              <CollecticonCirclePlay />
               Tour the US GHG Center
             </Button>
             <Button

--- a/overrides/home/component.tsx
+++ b/overrides/home/component.tsx
@@ -171,7 +171,7 @@ export default function HomeComponent() {
       {
         showModal && (
           <VideoModal 
-            iframe={<iframe width="560" height="315" src="https://www.youtube.com/embed/4JVd7pYel0w?si=2at04mgt69Wzt5Mm" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>}
+            iframe={<iframe width="560" height="315" src="https://www.youtube.com/embed/6xWdIlWqhBE?si=NpOVMavs4IgKE297" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen={true}></iframe>}
             display={showModal}
             onClose={() => setShowModal(false)}
             width={`${560*1.5}px`} // Iframe's original embed width value 1.5x bigger


### PR DESCRIPTION
<!-- -----------^ Click "Preview" for a functional view! -->

## Why are you creating this Pull Request?
Closes https://github.com/US-GHG-Center/ghgc-architecture/issues/198

This creates a video modal override component so we can display the GHGC Demo Video as part of the landing page

@j08lue @faustoperez I used our DS library's modal component to be quick so I didn't have to create the modal styles from scratch and the modal styles (like background opacity) matches the rest of where ever we use the modal (google-form). But because of this the _close button_ is closer to the video content instead of what was outlined in figma. This is because of the built in modal header in our DS Modal component. Will this be okay?

- [Adding Datasets or Stories](?title=Content%3A%20%3Cname%3E&expand=1&template=content.md)
- [Version Release](?title=Deploy%20vX.X.X&expand=1&template=version_release.md)
- [Other](?expand=1&template=default.md)