### PR TITLE
Update NOAA interfaces link to production links

### DIFF
--- a/datasets/noaa-cpfp-ch4-point.data.mdx
+++ b/datasets/noaa-cpfp-ch4-point.data.mdx
@@ -112,7 +112,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-gggrn-ghg-concentrations/index.html?ghg=ch4&frequency=all"
+      src="https://earth.gov/ghgcenter/custom-interfaces/noaa-gggrn-ghg-concentrations/index.html?ghg=ch4&frequency=all"
     />
   </Figure>
 </Block>

--- a/datasets/noaa-cpfp-co2-point.data.mdx
+++ b/datasets/noaa-cpfp-co2-point.data.mdx
@@ -112,7 +112,7 @@ layers:
   <Figure>
     <Embed
       height="800"
-      src="https://staging.earth.gov/ghgcenter/custom-interfaces/noaa-gggrn-ghg-concentrations/index.html?ghg=co2&frequency=all"
+      src="https://earth.gov/ghgcenter/custom-interfaces/noaa-gggrn-ghg-concentrations/index.html?ghg=co2&frequency=all"
     />
   </Figure>
 </Block>


### PR DESCRIPTION
## What am I changing and why

Updating NOAA interfaces links from staging to production

## How to test
Open NOAA datasets overview pages, in the embedded visualization, click open in new window. The link that opens should be earth.gov... instead of staging.earth.gov...