### PR TITLE
Update link to EMIT app in the Large Methane Emissions data insight

### DIFF
--- a/stories/discovering-large-methane-emissions.stories.mdx
+++ b/stories/discovering-large-methane-emissions.stories.mdx
@@ -193,7 +193,7 @@ taxonomy:
 
     <Block>
      <Figure>
-            <a href="/data-catalog/emit-ch4plume-v1" target="_blank" rel="noopener">
+            <a href="/data-catalog/emit-ch4plume-v1">
             <Image 
                 src={new URL('./emit-plume-map.png', import.meta.url).href}
                 alt="A map of the world with points representing methane plume locations distributed across all continents except antarctica." 

--- a/stories/discovering-large-methane-emissions.stories.mdx
+++ b/stories/discovering-large-methane-emissions.stories.mdx
@@ -193,7 +193,7 @@ taxonomy:
 
     <Block>
      <Figure>
-            <a href="/data-catalog/emit-ch4plume-v1">
+            <Link to="/data-catalog/emit-ch4plume-v1">
             <Image 
                 src={new URL('./emit-plume-map.png', import.meta.url).href}
                 alt="A map of the world with points representing methane plume locations distributed across all continents except antarctica." 
@@ -201,7 +201,7 @@ taxonomy:
                 attrAuthor="GHG Center"
                 width="256"
             />
-            </a>
+            </Link>
             <Caption> Locations of methane plumes observed with EMIT. </Caption>
         </Figure>
     </Block>

--- a/stories/discovering-large-methane-emissions.stories.mdx
+++ b/stories/discovering-large-methane-emissions.stories.mdx
@@ -193,7 +193,7 @@ taxonomy:
 
     <Block>
      <Figure>
-            <a href="https://nasa-impact.github.io/interactive-emission-plumes/" target="_blank" rel="noopener">
+            <a href="/data-catalog/emit-ch4plume-v1" target="_blank" rel="noopener">
             <Image 
                 src={new URL('./emit-plume-map.png', import.meta.url).href}
                 alt="A map of the world with points representing methane plume locations distributed across all continents except antarctica." 


### PR DESCRIPTION
This is the pull request to solve this [](https://github.com/US-GHG-Center/veda-config-ghg/issues/374) issue - https://github.com/US-GHG-Center/veda-config-ghg/issues/374

Approaches:
Changed the `a href="https://nasa-impact.github.io/interactive-emission-plumes/" target="_blank" rel="noopener"` to `/data-catalog/emit-ch4plume-v1` in the discovering-large-methane-emissions-stories.mdx file.
