### PR TITLE
Update `ghg.center` -> `earth.gov/ghgcenter`

### DIFF
--- a/stories/intro-us-ghg-center.stories.mdx
+++ b/stories/intro-us-ghg-center.stories.mdx
@@ -291,7 +291,7 @@ featured: true
         alt="feedback form for US GHG Center"
         align="center"
         attrAuthor="US GHG Center"
-        attrUrl="https://ghg.center"
+        attrUrl="https://earth.gov/ghgcenter"
         caption="US GHG Center Contact Form"
     />
     </a>


### PR DESCRIPTION
## What am I changing and why

Updating attrUrl for the feedback form image in Intro to US GHG Center story to be https://earth.gov/ghgcenter instead of https://ghg.center

## How to test
Go to the Intro to US GHG Center data insight page. Scroll down to the bottom until you see the feedback form screenshot. Hover over the (I) in the top right of the image and click it. It should take you to the US GHG Center homepage (earth.gov/ghgcenter) instead of to a broken URL.

![image](https://github.com/US-GHG-Center/veda-config-ghg/assets/7830949/4586692f-cbec-4c1d-8fe4-e648df453759)
