### PR TITLE
Open nbgitpuller links in JupyterLab

### DIFF
--- a/datasets/eccodarwin-co2flux-monthgrid-v5.data.mdx
+++ b/datasets/eccodarwin-co2flux-monthgrid-v5.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: "https://us-ghg-center.github.io/ghgc-docs/datausage.html"
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Feccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb&branch=main"
+  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Feccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb&branch=main"
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#eccodarwin-co2flux-monthgrid-v5/

--- a/datasets/emit-ch4plume-v1.data.mdx
+++ b/datasets/emit-ch4plume-v1.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/user_data_notebooks/emit-ch4plume-v1_User_Notebook.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Femit-ch4plume-v1_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Femit-ch4plume-v1_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://search.earthdata.nasa.gov/search/granules?p=C2748088093-LPCLOUD&pg[0][v]=f&pg[0][gsk]=-start_date&q=emit%20plume&tl=1694622854.77!3!!

--- a/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
+++ b/datasets/epa-ch4emission-yeargrid-v2express.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: "https://us-ghg-center.github.io/ghgc-docs/datausage.html"
     label: Notebooks to read, visualize, and explore data statistics
     title: "Data Usage Notebooks"
-  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fepa-ch4emission-grid-v2express_User_Notebook.ipynb&branch=main"
+  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fepa-ch4emission-grid-v2express_User_Notebook.ipynb&branch=main"
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#epa-ch4emission-yeargrid-v2express/

--- a/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
+++ b/datasets/gosat-based-ch4budget-yeargrid-v1.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fgosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fgosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account) 
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#gosat-based-ch4budget-yeargrid-v1/

--- a/datasets/lpjwsl-wetlandch4-grid-v2.data.mdx
+++ b/datasets/lpjwsl-wetlandch4-grid-v2.data.mdx
@@ -6,7 +6,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Flpjeosim-wetlandch4-grid-v2_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Flpjeosim-wetlandch4-grid-v2_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#lpjeosim-wetlandch4-daygrid-v2/

--- a/datasets/micasa-carbonflux-daygrid-v1.data.mdx
+++ b/datasets/micasa-carbonflux-daygrid-v1.data.mdx
@@ -6,7 +6,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fmicasa-carbonflux-daygrid-v1_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fmicasa-carbonflux-daygrid-v1_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#micasa-carbonflux-daygrid-v1/

--- a/datasets/oco2-mip-co2budget-yeargrid-v1.data.mdx
+++ b/datasets/oco2-mip-co2budget-yeargrid-v1.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Foco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Foco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#oco2-mip-co2budget-yeargrid-v1/

--- a/datasets/oco2geos-co2-daygrid-v10r.data.mdx
+++ b/datasets/oco2geos-co2-daygrid-v10r.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Foco2geos-co2-daygrid-v10r_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Foco2geos-co2-daygrid-v10r_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#oco2geos-co2-daygrid-v10r/

--- a/datasets/odiac-ffco2-monthgrid-v2022.data.mdx
+++ b/datasets/odiac-ffco2-monthgrid-v2022.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fodiac-ffco2-monthgrid-v2022_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fodiac-ffco2-monthgrid-v2022_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#odiac-ffco2-monthgrid-v2022/

--- a/datasets/sedac-popdensity-yeargrid5yr-v4.11.data.mdx
+++ b/datasets/sedac-popdensity-yeargrid5yr-v4.11.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: "https://us-ghg-center.github.io/ghgc-docs/datausage.html"
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fsedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb&branch=main"
+  - url: "https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fsedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb&branch=main"
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#sedac-popdensity-yeargrid5yr-v4.11/

--- a/datasets/tm54dvar-ch4flux-monthgrid-v1.data.mdx
+++ b/datasets/tm54dvar-ch4flux-monthgrid-v1.data.mdx
@@ -9,7 +9,7 @@ usage:
   - url: 'https://us-ghg-center.github.io/ghgc-docs/datausage.html'
     label: Notebooks to read, visualize, and explore data statistics
     title: 'Data Usage Notebooks'
-  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Ftm54dvar-ch4flux-monthgrid-v1_User_Notebook.ipynb&branch=main'
+  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Ftm54dvar-ch4flux-monthgrid-v1_User_Notebook.ipynb&branch=main'
     label: Run example notebook
     title: Interactive Session in the US GHG Center JupyterHub (requires account)
   - url: https://dljsq618eotzp.cloudfront.net/browseui/index.html#tm54dvar-ch4flux-monthgrid-v1/


### PR DESCRIPTION
This is the pull request to solve [this](https://github.com/US-GHG-Center/veda-config-ghg/issues/253) issue

Approach:
Replaced 
JupyterLab: urlpath=lab%2Ftree...
to Jupyter Notebook: urlpath=tree...

For all the mdx files inside datasets.
example, for micasa-carbonflux-daygrid-v1.data.mdx file 
 
**JupyterNotebook**
- url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=tree%2Fghgc-docs%2Fuser_data_notebooks%2Fmicasa-carbonflux-daygrid-v1_User_Notebook.ipynb&branch=main'

**JupyterLab**
  - url: 'https://hub.ghg.center/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUS-GHG-Center%2Fghgc-docs&urlpath=lab%2Ftree%2Fghgc-docs%2Fuser_data_notebooks%2Fmicasa-carbonflux-daygrid-v1_User_Notebook.ipynb&branch=main'
