### PR TITLE
increase timeout for webserver start

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
+    timeout: 2 * 60 * 1000,
     command: 'yarn serve',
     url: 'http://localhost:9000',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
The github action to run the playwright tests was failing: https://github.com/US-GHG-Center/veda-config-ghg/actions/runs/10182289431/job/28165170974

```
Error: Timed out waiting 60000ms from config.webServer.
```
This now happens for me locally, and it appears that the server was just taking too long to build and serve the site.  I extended the timeout for getting the site running before failing. 