### PR TITLE
pipe stdout to debug webserver start

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,9 +51,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    timeout: 2 * 60 * 1000,
+    timeout: 3 * 60 * 1000,
     command: 'yarn serve',
     url: 'http://localhost:9000',
     reuseExistingServer: !process.env.CI,
+    stdout: 'pipe'
   },
 });


### PR DESCRIPTION
the playwright action has intermittent timeouts while waiting for the webserver to start after running `yarn serve` and checking for a response on `http://localhost:9000`.  To ensure there are not other issues, I've added logging to see the outputs of that server startup step.