### PR TITLE
Use higher resolution tiles for MiCASA

### DIFF
--- a/datasets/micasa-carbonflux-daygrid-v1.data.mdx
+++ b/datasets/micasa-carbonflux-daygrid-v1.data.mdx
@@ -59,6 +59,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp-m
@@ -111,6 +112,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp
@@ -163,6 +165,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr-m
@@ -215,6 +218,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr
@@ -267,6 +271,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee-m
@@ -317,6 +322,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee
@@ -367,6 +373,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe-m
@@ -417,6 +424,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe
@@ -467,6 +475,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe-m
@@ -519,6 +528,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe
@@ -571,6 +581,7 @@ layers:
       rescale:
         - 0
         - 0.5
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel-m
@@ -621,6 +632,7 @@ layers:
       rescale:
         - 0
         - 0.5
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel
@@ -671,6 +683,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc-m
@@ -721,6 +734,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc


### PR DESCRIPTION
As discussed in

- Closes https://github.com/US-GHG-Center/ghgc-architecture/issues/220

This PR increases the rendered tile resolution on MiCASA layers by a factor 3 to lead to crispier data representation even when zoomed out.

This means that more data gets transferred to users. In some samples I tried, this was about 5x larger PNG files (despite 9x more pixels, possibly the difference is smaller due to additional compression during transfer).

https://earth.gov/ghgcenter/api/raster/searches/6009ffb8109e6c49299775dca06aff83/tiles/WebMercatorQuad/5/10/16@3x?assets=npp&colormap_name=purd&rescale=0%2C8

![16@1x](https://github.com/user-attachments/assets/e99905eb-0977-4f87-b0b7-aa39a3944eff)
![16@3x](https://github.com/user-attachments/assets/58f4e2ac-2a4e-4009-adf6-5f42a55973d9)