### PR TITLE
Fix/micasa tile scale 2

### DIFF
--- a/datasets/micasa-carbonflux-daygrid-v1.data.mdx
+++ b/datasets/micasa-carbonflux-daygrid-v1.data.mdx
@@ -59,7 +59,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp-m
@@ -112,7 +112,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp
@@ -165,7 +165,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr-m
@@ -218,7 +218,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr
@@ -271,7 +271,7 @@ layers:
       rescale:
         - -4
         - 4
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee-m
@@ -322,7 +322,7 @@ layers:
       rescale:
         - -4
         - 4
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee
@@ -373,7 +373,7 @@ layers:
       rescale:
         - -4
         - 4
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe-m
@@ -424,7 +424,7 @@ layers:
       rescale:
         - -4
         - 4
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe
@@ -475,7 +475,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe-m
@@ -528,7 +528,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe
@@ -581,7 +581,7 @@ layers:
       rescale:
         - 0
         - 0.5
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel-m
@@ -632,7 +632,7 @@ layers:
       rescale:
         - 0
         - 0.5
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel
@@ -683,7 +683,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc-m
@@ -734,7 +734,7 @@ layers:
       rescale:
         - 0
         - 8
-      tile_scale: 3
+      tile_scale: 2
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc

--- a/datasets/micasa-carbonflux-daygrid-v1.data.mdx
+++ b/datasets/micasa-carbonflux-daygrid-v1.data.mdx
@@ -59,6 +59,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp-m
@@ -111,6 +112,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-npp
@@ -163,6 +165,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr-m
@@ -215,6 +218,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-hr
@@ -267,6 +271,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee-m
@@ -317,6 +322,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nee
@@ -367,6 +373,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe-m
@@ -417,6 +424,7 @@ layers:
       rescale:
         - -4
         - 4
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-nbe
@@ -467,6 +475,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe-m
@@ -519,6 +528,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fe
@@ -571,6 +581,7 @@ layers:
       rescale:
         - 0
         - 0.5
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel-m
@@ -621,6 +632,7 @@ layers:
       rescale:
         - 0
         - 0.5
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-flux-fuel
@@ -671,6 +683,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc-m
@@ -721,6 +734,7 @@ layers:
       rescale:
         - 0
         - 8
+      tile_scale: 3
     compare:
       datasetId: micasa-carbonflux-grid-v1
       layerId: micasa-co2-atmc


### PR DESCRIPTION
For comparison with https://github.com/US-GHG-Center/veda-config-ghg/pull/630, which implements tile_scale: 3



