### PR TITLE
[Do not merge] Test/sitealert banner

### DIFF
--- a/veda.config.js
+++ b/veda.config.js
@@ -90,11 +90,9 @@ module.exports = {
         "This dashboard is for exploring key datasets that provide insight into greenhouse gas sources, sinks, emissions, fluxes, and events.",
     // Temporary Banner Text/URL/expiry
     tempBanner:
-        "Read the new story on using EMIT and AVIRIS-3 for monitoring large methane emission events.",
-    tempBannerUrl:
-      "stories/emit-and-aviris-3",
+        "Temporary Banner",
     tempBannerExpires:
-        "2024-07-03T12:00:00-04:00"
+        "2025-07-03T12:00:00-04:00"
   },
 
   theme: {

--- a/veda.config.js
+++ b/veda.config.js
@@ -32,6 +32,21 @@ let subNavItems = [
   },
 ]
 
+const defaultGuidance = {
+  left: {
+    title: 'Official websites use .gov',
+    text: 'A **.gov** website belongs to an official government organization in the United States.',
+    iconAlt: 'Dot gov icon',
+    icon: '/img/icon-dot-gov.svg'
+  },
+  right: {
+    title: 'Secure .gov websites use HTTPS',
+    text: "A **lock icon** or **https://** means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.",
+    iconAlt: 'HTTPS icon',
+    icon: '/img/icon-https.svg'
+  }
+};
+
 if (config.GOOGLE_FORM) {
   subNavItems = [
     ...subNavItems,
@@ -90,9 +105,11 @@ module.exports = {
         "This dashboard is for exploring key datasets that provide insight into greenhouse gas sources, sinks, emissions, fluxes, and events.",
     // Temporary Banner Text/URL/expiry
     tempBanner:
-        "Temporary Banner",
+        "Read the new story on using EMIT and AVIRIS-3 for monitoring large methane emission events.",
+    tempBannerUrl:
+      "stories/emit-and-aviris-3",
     tempBannerExpires:
-        "2025-07-03T12:00:00-04:00"
+        "2024-07-03T12:00:00-04:00"
   },
 
   theme: {
@@ -120,5 +137,33 @@ module.exports = {
   navItems: {
     mainNavItems: defaultMenuLinks,
     subNavItems: subNavItems
-  }
+  },
+  cookieConsentForm: {
+    title: 'Cookie Consent',
+    copy: 'We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies)',
+    theme: {
+      card: {
+        backgroundColor: '#2276ac',
+        sideBarColor: '#175074',
+        textColor: 'White',
+        linkColor: '#175074'
+      },
+      acceptButton: {
+        default: { backgroundColor: '#175074', textColor: 'white' },
+        hover: { backgroundColor: '#2c3e50', textColor: '#white' }
+      },
+      declineButton: {
+        default: { borderColor: '#175074', textColor: '#175074' },
+        hover: { borderColor: '#2c3e50', textColor: '#2c3e50' }
+      },
+      iconColor: { default: 'White', hover: '#175074' }
+    }
+  },
+  siteAlert: {
+    content: `[Discover insights on how the COVID-19 pandemic](stories/life-of-water) impacted air quality worldwide, observed through NASA's satellite data.`,
+    expires: '2026-08-03T12:00:00-04:00',
+    type: 'info',
+    slim: true,
+    showIcon: true
+  },
 };

--- a/veda.config.js
+++ b/veda.config.js
@@ -159,6 +159,18 @@ module.exports = {
       iconColor: { default: 'White', hover: '#175074' }
     }
   },
+  banner: {
+    headerText: 'An official website of the United States government',
+    headerActionText: "Here's how you know",
+    ariaLabel: 'Banner for official government website',
+    flagImgSrc: '/img/us_flag_small.png',
+    flagImgAlt: 'US flag',
+    leftGuidance: defaultGuidance.left,
+    rightGuidance: defaultGuidance.right,
+    className: '',
+    defaultIsOpen: false,
+    contentId: 'gov-banner-content'
+  },
   siteAlert: {
     content: `[Discover insights on how the COVID-19 pandemic](stories/life-of-water) impacted air quality worldwide, observed through NASA's satellite data.`,
     expires: '2026-08-03T12:00:00-04:00',


### PR DESCRIPTION
This PR tests the addition banner, site alerts and cookie consent form to GHGC portal.
Reference : https://github.com/NASA-IMPACT/veda-ui/blob/3e9ce51e909b2eea78d4c108e8c37a9e49374ef8/mock/veda.config.js


It requires the the following env vars to be set in the .env file
`COOKIE_CONSENT_FORM = 'TRUE'`