### PR TITLE
Veda UI revert back to v5.13.1

### DIFF
--- a/veda.config.js
+++ b/veda.config.js
@@ -135,7 +135,7 @@ module.exports = {
     'externalLinksInNewTab': true,
   },
   navItems: {
-    headerNavItems: defaultMenuLinks,
+    mainNavItems: defaultMenuLinks,
     subNavItems: subNavItems
   },
   cookieConsentForm: {


### PR DESCRIPTION
Note: Not proceeding with the latest veda-ui (v6.1.1) due to assets not loading up in staging.