### PR TITLE
Tweak GHGC header when in E&A

### DIFF
--- a/common/styles.scss
+++ b/common/styles.scss
@@ -42,13 +42,6 @@
   top: 0;
 }
 
-.banner--left-aligned {
-  & .usa-banner__inner,
-  & .usa-banner__content {
-    margin: auto;
-  }
-}
-
 // hardcoded to override the USWDS styles coming from veda-ui, until
 // https://github.com/NASA-IMPACT/veda-ui/issues/1573 is resolved
 li.usa-card {

--- a/overrides/components/header-brand/component.tsx
+++ b/overrides/components/header-brand/component.tsx
@@ -3,6 +3,8 @@ import styled from "$veda-ui/styled-components";
 import { glsp, themeVal } from "$veda-ui/@devseed-ui/theme-provider";
 import { Link } from "$veda-ui/react-router-dom";
 
+import '/common/styles.scss';
+
 const Brand = styled.div`
   position: relative;
   display: flex;

--- a/styles/theme.scss
+++ b/styles/theme.scss
@@ -2,3 +2,14 @@
 @forward 'uswds';
 
 @use 'uswds-core' as *;
+
+
+.usa-banner__header {
+    .usa-banner__button:after {
+        top: 0;
+    }
+
+    .usa-accordion__button {
+        height: auto;
+    }
+}


### PR DESCRIPTION
- Height misalignment tweak to match the rest of the pages

Noticed on the latest staging deployment

<img width="840" alt="Screenshot 2025-04-04 at 18 25 36" src="https://github.com/user-attachments/assets/84313791-c90f-4341-9b67-ad9376f39540" />
