### PR TITLE
Updated Temporal extent for INFLUX data

### DIFF
--- a/datasets/influx-testbed-co2-and-ch4-concentrations.data.mdx
+++ b/datasets/influx-testbed-co2-and-ch4-concentrations.data.mdx
@@ -41,7 +41,7 @@ taxonomy:
       - CH₄
 infoDescription: |
   ::markdown
-    - Temporal Extent: January 1, 2011 - December 31, 2023    
+    - Temporal Extent: January 1, 2011 - December 31, 2024   
     - Temporal Resolution: Hourly averages    
     - Spatial Extent: Indianapolis, Indiana, United States   
     - Spatial Resolution: Point location samples    
@@ -101,7 +101,7 @@ layers:
 
 <Block>
   <Prose>
-    **Temporal Extent:** January 1, 2011 - December 31, 2023    
+    **Temporal Extent:** January 1, 2011 - December 31, 2024    
     **Temporal Resolution:**  Hourly averages    
     **Spatial Extent:** Indianapolis, Indiana, United States   
     **Spatial Resolution:** Point location samples    


### PR DESCRIPTION
Update for the INFLUX dataset overview page. 
The end date for the temporal extent at the top should be updated to 2024. 

Changes tracked here: [Website Info_INFLUX Urban Test Bed Tower Data](https://docs.google.com/document/d/1Xo23N3zs2LcsErWzKKAHw5fodDMhxK3XwIZZ4VBz2so/edit?tab=t.0)