### PR TITLE
fix: Update hyperlink

### DIFF
--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -138,7 +138,7 @@ taxonomy:
             * <Link to='/data-catalog/noaa-gggrn-ch4-concentrations'>NOAA station-based CH₄ observations</Link>
             * <Link to='/data-catalog/lpjeosim-wetlandch4-grid-v1'>Daily and monthly wetland emissions</Link>
             * <Link to='/data-catalog/gosat-based-ch4budget-yeargrid-v1'>Alternate estimates of CH₄ emissions using data from Japan’s GOSAT</Link>
-            * <Link to='/data-catalog/tm54dvar-ch4flux-monthgrid-v1'>Estimates of CH₄ emissions based on isotopic data collected at surface stations</Link>
+            * <Link to='/data-catalog/ct-ch4-monthgrid-v2023'>Estimates of CH₄ emissions based on isotopic data collected at surface stations</Link>
     </Prose>
 </Block>
 


### PR DESCRIPTION
Fix hyperlink in [Tracking Greenhouse Gas Cycles story](https://earth.gov/ghgcenter/stories/tracking-greenhouse-gas-cycles) 

Change [Estimates of CH₄ emissions based on isotopic data collected at surface stations](https://earth.gov/ghgcenter/data-catalog/tm54dvar-ch4flux-monthgrid-v1) link to (https://earth.gov/ghgcenter/data-catalog/ct-ch4-monthgrid-v2023)