### PR TITLE
fix: update banner credit for CarbonTracker

### DIFF
--- a/datasets/ct-ch4-monthgrid-v2023.data.mdx
+++ b/datasets/ct-ch4-monthgrid-v2023.data.mdx
@@ -20,7 +20,7 @@ media:
   src: ::file ./media/ct-ch4-monthgrid-v2023-cover.jpg
   alt: Landfill
   author:
-    name:  Figure by Matt Ziminski and Youmi Oh
+    name: Matt Ziminski and Youmi Oh
     url:  https://gml.noaa.gov/ccgg/carbontracker-ch4/
 taxonomy:
   - name: Topics


### PR DESCRIPTION
update banner credit on the [CarbonTracker dataset page](https://earth.gov/ghgcenter/data-catalog/ct-ch4-monthgrid-v2023) to remove the duplicate "Figure by"