### PR TITLE
Release v3.1.17

### DIFF
--- a/datasets/ct-ch4-monthgrid-v2023.data.mdx
+++ b/datasets/ct-ch4-monthgrid-v2023.data.mdx
@@ -20,7 +20,7 @@ media:
   src: ::file ./media/ct-ch4-monthgrid-v2023-cover.jpg
   alt: Landfill
   author:
-    name:  Figure by Matt Ziminski and Youmi Oh
+    name: Matt Ziminski and Youmi Oh
     url:  https://gml.noaa.gov/ccgg/carbontracker-ch4/
 taxonomy:
   - name: Topics

--- a/datasets/sedac-popdensity-yeargrid5yr-v4.11.data.mdx
+++ b/datasets/sedac-popdensity-yeargrid5yr-v4.11.data.mdx
@@ -94,14 +94,6 @@ layers:
       alt: SEDAC Gridded World Population Density - Population Density
 
 ---
-<Block>
-  <Prose>
-    <div style={{ border: '2px solid red', padding: '10px', display: 'inline-block', color: '#1b2631' }}>
-      <span style={{ color: 'red', fontWeight: 'bold' }}>Attention!</span>
-      SEDAC data and information are no longer being updated at this time. The information on Earthdata represents the best data and information available for SEDAC before March 7, 2025.
-    </div>
-  </Prose>
-</Block>
 
 <Block>
   <Prose> 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {

--- a/static/public/subscription/index.html
+++ b/static/public/subscription/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='UTF-8'>
   <!-- Begin Constant Contact Active Forms -->
-  <script> var _ctct_m = "659a6c1e1b34f5b0f7de2c2640663bee"; </script>
+  <script> var _ctct_m = "ed1335acd531ca5fb0b3228ccc3095cc"; </script>
   <script id="signupScript" src="//static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js" async defer></script>
   <!-- End Constant Contact Active Forms -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10..0,100..900&amp;display=swap" rel="stylesheet">
@@ -17,18 +17,18 @@
       </div>
 
       <!-- Begin Downtime Banner -->
-      <div class="banner">
+      <!-- <div class="banner">
         <h2>Newsletter Sign-Up Temporarily Unavailable</h2>
       <div class="banner-content">
         <p>
           We are unable to take new subscribers to our newsletter at this time. Our support team is aware of the issue and will make a new subscription form available here when service resumes. We apologize for the inconvenience.
         </p>
       </div>  
-      </div>
+      </div> -->
       <!-- End Downtime Banner -->
 
       <!-- Begin Constant Contact Inline Form Code -->
-      <!-- <div class="ctct-inline-form" data-form-id="8c362d9d-9d4e-47b9-ac42-18110a8bbf18"></div> -->
+      <div class="ctct-inline-form" data-form-id="a22597a8-95c8-41e4-a71a-568aeaca2dd3"></div>
       <!-- End Constant Contact Inline Form Code -->
     </div>
   </div>

--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -138,7 +138,7 @@ taxonomy:
             * <Link to='/data-catalog/noaa-gggrn-ch4-concentrations'>NOAA station-based CH₄ observations</Link>
             * <Link to='/data-catalog/lpjeosim-wetlandch4-grid-v1'>Daily and monthly wetland emissions</Link>
             * <Link to='/data-catalog/gosat-based-ch4budget-yeargrid-v1'>Alternate estimates of CH₄ emissions using data from Japan’s GOSAT</Link>
-            * <Link to='/data-catalog/tm54dvar-ch4flux-monthgrid-v1'>Estimates of CH₄ emissions based on isotopic data collected at surface stations</Link>
+            * <Link to='/data-catalog/ct-ch4-monthgrid-v2023'>Estimates of CH₄ emissions based on isotopic data collected at surface stations</Link>
     </Prose>
 </Block>
 


### PR DESCRIPTION
# Changelog
- ## :tada: Features
  - feat: time series support for CMR data ([#1747](https://github.com/NASA-IMPACT/veda-ui/pull/1747))
- ## :rocket: Improvements
  - chore: Develop custom layer example ([#1757](https://github.com/NASA-IMPACT/veda-ui/pull/1757))
  - chore: Deprecate mosaic endpoint ([#1773](https://github.com/NASA-IMPACT/veda-ui/pull/1773))
  - ci: Send warning when release terminated with no commit ([#1779](https://github.com/NASA-IMPACT/veda-ui/pull/1779))
- ## :bar_chart: Dataset Updates
  - fix: Do not show configurable colormap for wms, wmts datasets ([#1769](https://github.com/NASA-IMPACT/veda-ui/pull/1769))
  - fix: update banner credit for CarbonTracker dataset ([#814](https://github.com/US-GHG-Center/veda-config-ghg/pull/814))
 - ## :bug: Fixes
   - fix: render extension logic ([#1772](https://github.com/NASA-IMPACT/veda-ui/pull/1772))
   - fix: Pin down react compare image ([#1785](https://github.com/NASA-IMPACT/veda-ui/pull/1785))
   - fix: newsletter subscription form ([#813](https://github.com/US-GHG-Center/veda-config-ghg/pull/813))