### PR TITLE
fix: Revert external image URLs mistakenly renamed to .webp

### DIFF
--- a/datasets/influx-testbed-co2-and-ch4-concentrations.data.mdx
+++ b/datasets/influx-testbed-co2-and-ch4-concentrations.data.mdx
@@ -20,7 +20,7 @@ media:
   alt: Roadways in Indianapolis, Indiana near a tower station estimating local greenhouse gas emissions
   author:
     name: Pennsylvania State University
-    url: https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.webp
+    url: https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.png
 taxonomy:
   - name: Topics
     values:

--- a/stories/epa-super-emitter.stories.mdx
+++ b/stories/epa-super-emitter.stories.mdx
@@ -33,7 +33,7 @@ taxonomy:
                 alt="two images earth surface with red areas marking methane plumes and instrument shape on upper right of each image, aircraft on left and satellite on right"
                 align="left"
                 attrAuthor="NASA-JPL/Caltech/GSFC"
-                attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.webp "
+                attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.png "
                 width="100%"
             />
             <Caption>

--- a/stories/intro-us-ghg-center.stories.mdx
+++ b/stories/intro-us-ghg-center.stories.mdx
@@ -86,21 +86,12 @@ pubDate: 2023-08-23
     <video
       style={{ width: "100%", aspectRatio: "16/9" }}
       controls
-      poster="https://climate.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMDFPQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--625a5db12a30c6208405d52533ba502db05d85aa/Greenhouse_effect_revised_HD_English.jpg?disposition=inline"
       autoplay
       muted
     >
       <source
-        src="https://climate.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdmtzIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--3c5bdbccda698f2bb9080f616910b91a8460edd1/Greenhouse_effect_revised_HD_English.m4v?disposition=inline"
+        src="https://science.nasa.gov/wp-content/uploads/2014/09/126-greenhouse-effect-revised-hd-english.m4v"
         type="video/mp4"
-      />
-      <source
-        src="https://climate.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdm9zIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--cd1c41552f94113c41384dcbfbdc0fd8087cc468/Greenhouse_effect_revised_HD_English.webm?disposition=inline"
-        type="video/webm"
-      />
-      <source
-        src="https://climate.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdnNzIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d6dbdbcd8fd556e8b1959dcc96940fae7b20f076/Greenhouse_effect_revised_HD_English.ogv?disposition=inline"
-        type="video/ogg"
       />
       Your browser does not support the video tag.
     </video>

--- a/stories/intro-us-ghg-center.stories.mdx
+++ b/stories/intro-us-ghg-center.stories.mdx
@@ -50,12 +50,12 @@ pubDate: 2023-08-23
   <Figure>
     <Image
       src={
-        new URL("https://www.climate.gov/sites/default/files/2024-01/2023-billion-dollar-disaster-map.webp", import.meta.url).href
+        new URL("https://www.climate.gov/sites/default/files/2024-01/2023-billion-dollar-disaster-map.png", import.meta.url).href
       }
       alt="Map presenting billion-dollar events"
       align="left"
       attrAuthor="NOAA"
-      attrUrl="https://www.climate.gov/sites/default/files/2024-01/2023-billion-dollar-disaster-map.webp"
+      attrUrl="https://www.climate.gov/sites/default/files/2024-01/2023-billion-dollar-disaster-map.png"
     />
     <Caption>
       {" "}

--- a/stories/nist-methane-intercomparisons.stories.mdx
+++ b/stories/nist-methane-intercomparisons.stories.mdx
@@ -86,7 +86,7 @@ import Quote from "./components/quote";
                 alt="satellite in orbit over earth with colorful area indicating measured data"
                 align="left"
                 attrAuthor="MethaneSAT/Environmental Defense Fund"
-                attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.webp "
+                attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.png "
                 width="100%"
             />
             <Caption>

--- a/stories/nist-urban-testbeds.stories.mdx
+++ b/stories/nist-urban-testbeds.stories.mdx
@@ -8,7 +8,7 @@ media:
    alt: street view of a city with tower in distance showing image of instruments on tower
    author:
      name: INFLUX project / NIST
-     url: "https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.webp"
+     url: "https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.png"
 pubDate: 2024-09-20
 taxonomy:
   - name: Topics
@@ -49,7 +49,7 @@ import Quote from "./components/quote";
             alt="street view of a city with tower in distance showing image of instruments on tower"
             align="left"
             attrAuthor="INFLUX project / NIST"
-            attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.webp "
+            attrUrl="https://bpb-us-e1.wpmucdn.com/sites.psu.edu/dist/9/4276/files/2023/09/US_INC.png "
             width="100%"
         />
         <Caption>

--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -145,13 +145,11 @@ taxonomy:
 
 <Block>
     <Figure>
-        <Image 
-            src={new URL('./media/net-carbon-emissions.mp4', import.meta.url).href}
-            alt="NASA animation of country-level CO₂ emissions inferred from atmospheric observations " 
-            align="left"
-            attrAuthor=" NASA Science Visualization Studio/Greg Shirah and Helen-Nicole Kostis"
-            attrUrl="https://svs.gsfc.nasa.gov/vis/a000000/a005000/a005081/NetCarbonEmissions_Light_1920x1080_30fps.mp4"
-        />
+        <video style={{ width: '100%', aspectRatio: "16/9" }} controls autoplay muted>
+            <source src="https://svs.gsfc.nasa.gov/vis/a000000/a005000/a005081/NetCarbonEmissions_Light_1920x1080_30fps.webm" type="video/webm" />
+            <source src="https://svs.gsfc.nasa.gov/vis/a000000/a005000/a005081/NetCarbonEmissions_Light_1920x1080_30fps.mp4" type="video/mp4" />
+            Your browser does not support the video tag.
+        </video>
         <Caption> Models use observations from NOAA’s network of surface stations and NASA’s OCO-2 satellite to estimate net emissions and removals of CO₂, which reflect the combined impact of fossil fuel emissions and absorption by land and ocean sinks. Variability highlights the role of the 2015-2016 El Nino that resulted in increased emissions from tropical ecosystems as well as large fire events like those in Australia during 2020. </Caption>
     </Figure>
     <Prose>

--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -51,8 +51,8 @@ taxonomy:
 <Block>
     <Figure>
         <video style={{ width: '100%', aspectRatio: "16/9" }} poster={new URL('./media/screenshot-co2-explainer.webp', import.meta.url).href} controls autoplay muted>
-            <source src="/vis/a000000/a005100/a005110/CO2composite.webm" type="video/webm" />
-            <source src="/vis/a000000/a005100/a005110/CO2composite.mp4" type="video/mp4" />
+            <source src="https://svs.gsfc.nasa.gov/vis/a000000/a005100/a005110/CO2composite.webm" type="video/webm" />
+            <source src="https://svs.gsfc.nasa.gov/vis/a000000/a005100/a005110/CO2composite.mp4" type="video/mp4" />
             Your browser does not support the video tag.
         </video>
         {/* <iframe src="https://svs.gsfc.nasa.gov/prepub/mark/drafts/CO2explainer.mp4" width="800" height="480" allow="autoplay"></iframe> */}

--- a/stories/tracking-greenhouse-gas-cycles.stories.mdx
+++ b/stories/tracking-greenhouse-gas-cycles.stories.mdx
@@ -51,9 +51,10 @@ taxonomy:
 <Block>
     <Figure>
         <video style={{ width: '100%', aspectRatio: "16/9" }} poster={new URL('./media/screenshot-co2-explainer.webp', import.meta.url).href} controls autoplay muted>
-            <source src="https://svs.gsfc.nasa.gov/vis/a000000/a005100/a005110/CO2explainer_1080p30.mp4" type="video/mp4"/>
+            <source src="/vis/a000000/a005100/a005110/CO2composite.webm" type="video/webm" />
+            <source src="/vis/a000000/a005100/a005110/CO2composite.mp4" type="video/mp4" />
             Your browser does not support the video tag.
-        </video> 
+        </video>
         {/* <iframe src="https://svs.gsfc.nasa.gov/prepub/mark/drafts/CO2explainer.mp4" width="800" height="480" allow="autoplay"></iframe> */}
         <Caption> This animation combines information from NASA models and datasets featured on the US GHG Center to track the influences on atmospheric CO₂ over the course of a year. Global views highlight the influence of fossil fuel and fire emissions in the atmosphere and land and ocean sinks at the surface using different colors. The waterfall diagram shows estimates of the global contributions of major sources and sinks and illustrates how their balance shifts with the season. At the end of the year, the land and ocean have absorbed nearly half of CO₂ emissions. *Video Credit: NASA Science Visualization Studio/Anansa Keaton-Ashanti and Mark SubbaRao* </Caption>
     </Figure>


### PR DESCRIPTION
The media compression pass (#859) rewrote all .png references to .webp, including two externally hosted images that were never converted and now 404:
- bpb-us-e1.wpmucdn.com .../US_INC.png
- climate.gov .../2023-billion-dollar-disaster-map.png