### PR TITLE
Use video tags for gifs that were converted to mp4

### DIFF
--- a/stories/emit-and-aviris-3.stories.mdx
+++ b/stories/emit-and-aviris-3.stories.mdx
@@ -158,6 +158,7 @@ taxonomy:
             height="600"
             controls
             autoplay
+            muted
             loop
             poster={new URL('./media/EMIT_AVIRIS3_Video_Image_Play_Arrow_Middle.webp', import.meta.url).href}
             >
@@ -176,10 +177,12 @@ taxonomy:
             height="800"
             autoplay
             loop
+            controls
+            muted
         >
         </video>
         <Caption attrAuthor="NASA/JPL-Caltech" alt="Alternating image showing EMIT and AVIRIS-3 coincidently measured methane plume" >
-            GIF of EMIT and AVIRIS-3 methane plume observations for the emission source. Coincident observations permit comparison of emission estimates derived from AVIRIS-3 and EMIT.
+            Video of EMIT and AVIRIS-3 methane plume observations for the emission source. Coincident observations permit comparison of emission estimates derived from AVIRIS-3 and EMIT.
         </Caption>
     </Figure>
 </Block>

--- a/stories/losangeles.stories.mdx
+++ b/stories/losangeles.stories.mdx
@@ -81,16 +81,18 @@ taxonomy:
 
   </Prose>
   <Figure>
-      <Image 
+      <video
         src={new URL('./media/oco3 snapshot Los A v3 fr2.mp4', import.meta.url).href}
-        alt="movie showing monthly OCO-3 carbon dioxide concentration values over the Los Angeles area for several random months from May 2020 to October 2022." 
-        align="left"
-        attrAuthor="NASA JPL/ Matthäus Kiel"
-        attrUrl="https://www.jpl.nasa.gov/"
-        caption="Measurements from OCO-3 snapshot area maps helped to reveal a decrease in carbon dioxide concentration over the city of Los Angeles in 2020 associated with fewer cars on the road during the height of the Covid-19 pandemic, followed by an increase in 2021 and 2022 as road traffic returned to pre-pandemic levels." 
         width="100%"
-        height="60%"
-      />
+        controls
+        autoplay
+        loop
+        muted
+      >
+      </video>
+      <Caption attrAuthor="NASA JPL/ Matthäus Kiel" attrUrl="https://www.jpl.nasa.gov/" alt="movie showing monthly OCO-3 carbon dioxide concentration values over the Los Angeles area for several random months from May 2020 to October 2022.">
+        Measurements from OCO-3 snapshot area maps helped to reveal a decrease in carbon dioxide concentration over the city of Los Angeles in 2020 associated with fewer cars on the road during the height of the Covid-19 pandemic, followed by an increase in 2021 and 2022 as road traffic returned to pre-pandemic levels.
+      </Caption>
   </Figure>
 </Block>
 

--- a/stories/sanfrancisco.stories.mdx
+++ b/stories/sanfrancisco.stories.mdx
@@ -45,14 +45,18 @@ taxonomy:
         With a web of sensors in place, known as the Berkeley Environmental Air Quality and CO₂ Network, the team monitors immediate changes, such as a spike in pollution from wildfires, as well as tracking emissions over time.
         
         <Figure>
-            <Image 
+            <video
             src={new URL('./media/Firework_movie.mp4', import.meta.url).href}
-            alt="movie showing two plots side by side - one a data plot, the other a map of sensor data locations and values in the San Francisco bay area from July 3 midnight to July 6 midnight local time." 
-            align="left"
-            attrAuthor="Naomi Asimow / Berkeley Environmental Air Quality and CO₂ Network"
-            caption="On Monday, July 4th, 2022, several sites in the Alameda County part of the Bay Area began to set off fireworks at 10 p.m. These fireworks resulted in large spikes in fine particulate matter caused by the firework colorants and explosives. The spikes were recorded by Berkeley Environmental Air Quality and CO₂ Network sensors. Darker shades of orange and red represent the highest concentrations of pollutants." 
             width="100%"
-            />
+            controls
+            autoplay
+            loop
+            muted
+            >
+            </video>
+            <Caption attrAuthor="Naomi Asimow / Berkeley Environmental Air Quality and CO₂ Network" alt="movie showing two plots side by side - one a data plot, the other a map of sensor data locations and values in the San Francisco bay area from July 3 midnight to July 6 midnight local time.">
+                On Monday, July 4th, 2022, several sites in the Alameda County part of the Bay Area began to set off fireworks at 10 p.m. These fireworks resulted in large spikes in fine particulate matter caused by the firework colorants and explosives. The spikes were recorded by Berkeley Environmental Air Quality and CO₂ Network sensors. Darker shades of orange and red represent the highest concentrations of pollutants.
+            </Caption>
         </Figure>
     </Prose>
 </Block>


### PR DESCRIPTION
The media compression pass converted these gifs to mp4 but left the <Image> components in place, which can't render video. Replaced them with the <video> + <Caption> pattern already used elsewhere (e.g. emit-and-aviris-3), preserving alt text, attribution, and captions.